### PR TITLE
Fix readme optional prop example compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ export default SomeComponent;
 
   * **`onChangeAccount`** *(Function)*:  Callback which is called when the user switches to
   a new account. Callback will receive the new ETH address as an argument.
-    * **Example:** `onChangeAccount={nextAddress => console.log(nextAddress)}`
+    * **Example:** `const onChangeAccount = (nextAddress) => (console.log(nextAddress))`
   * **`web3UnavailableScreen`** *(ReactElement)*: React component to override the screen that is
   shown when web3 is unavailable.
-    * **Example:** `web3UnavailableScreen={() => <div>You need web3!</div>}`
+    * **Example:** `const web3UnavailableScreen = () => (<div>You need web3!</div>)}`
   * **`accountUnavailableScreen`** *(ReactElement)*: React component to override the screen that
   is shown when the user's wallet is locked.
-    * **Example:** `accountUnavailableScreen={() => <div>Please unlock your wallet!</div>}`
+    * **Example:** `const accountUnavailableScreen = () => (<div>Please unlock your wallet!</div>)`
   * **`passive`** *(Boolean)*: If true, your app will be rendered right away
   even if an ETH address is not available, and the message screens will become
   irrelevant and never be rendered. This is useful for apps that don't

--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -124,7 +124,7 @@ class Web3Provider extends React.Component {
     curr = curr && curr.toLowerCase();
     const didChange = curr && next && (curr !== next);
 
-    if (!isConstructor) {
+    if (didChange && !isConstructor) {
       this.setState({
         accountsError: null,
         accounts


### PR DESCRIPTION
When I used examples as given, I got this error:
```
./src/App.js
Syntax error: Unexpected token, expected , (34:29)

  32 | 
  33 | 
> 34 | onChangeAccount={nextAddress => console.log(nextAddress)}
     |                              ^
  35 | web3UnavailableScreen={() => <div>You need web3!</div>}
  36 | accountUnavailableScreen={() => <div>Please unlock your wallet!</div>}
  37 | 
```

I was able to fix by changing format to :
```
const onChangeAccount = (nextAddress) => (console.log(nextAddress))
const web3UnavailableScreen = () => (<div>You need web3!</div>)
const accountUnavailableScreen = () => (<div>Please unlock your wallet!</div>)
```

I'm new to react and modern node, so take with grain of salt. 