### PR TITLE
Added `didChange` check to prevent updated state each second

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -124,6 +124,13 @@ class Web3Provider extends React.Component {
     curr = curr && curr.toLowerCase();
     const didChange = curr && next && (curr !== next);
 
+    if (isEmpty(this.state.accounts) && !isEmpty(accounts)) {
+      this.setState({
+        accountsError: null,
+        accounts: accounts
+      });
+    }
+
     if (didChange && !isConstructor) {
       this.setState({
         accountsError: null,

--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -167,10 +167,12 @@ class Web3Provider extends React.Component {
           networkError: err
         });
       } else {
-        this.setState({
-          networkError: null,
-          networkId: netId
-        })
+        if (netId != this.state.networkId) {
+          this.setState({
+            networkError: null,
+            networkId: netId
+          })
+        }
       }
     });
   }

--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -124,7 +124,7 @@ class Web3Provider extends React.Component {
     curr = curr && curr.toLowerCase();
     const didChange = curr && next && (curr !== next);
 
-    if (!isConstructor) {
+    if (didChange && !isConstructor) {
       this.setState({
         accountsError: null,
         accounts


### PR DESCRIPTION
`handleAccounts()` was calling `setState()` every second even when nothing changed. This triggered constant re-renders of the app, making text entry fields un-fillable.
With this fix state changes only when users change account.