### PR TITLE
No setState in fetchNetwork() when no change, & handleAccounts() fix

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -124,7 +124,7 @@ class Web3Provider extends React.Component {
     curr = curr && curr.toLowerCase();
     const didChange = curr && next && (curr !== next);
 
-    if (!isConstructor) {
+    if (didChange && !isConstructor) {
       this.setState({
         accountsError: null,
         accounts


### PR DESCRIPTION
fetchNetwork() is called every minute, and would call setState() even when network hadn't changed. This triggered app refresh, clearing any text entry fields.  Added a check that network is changed before setState is called:
```
        if (netId != this.state.networkId) {
          this.setState({
            networkError: null,
            networkId: netId
          })
        }
```

Also added code to handleAccounts() to *do* a setState() when `this.state.accounts` is empty: This is when web3 is first detected, and a state change is needed. 
```
    if (isEmpty(this.state.accounts) && !isEmpty(accounts)) {
      this.setState({
        accountsError: null,
        accounts: accounts
      });
    }
```