### PR TITLE
Fix exception caused by window.web3

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -199,10 +199,10 @@ class Web3Provider extends React.Component {
    */
   getAccounts() {
     const { web3 } = window;
-    const isV1 = /^1/.test(web3.version);
 
     try {
       const { web3 } = window;
+      const isV1 = /^1/.test(web3.version);
       // throws if no account selected
       const getV1Wallets = () => range(web3.eth.accounts.wallet.length).map(i => web3.eth.accounts.wallet[i]).map(w => w.address);
       const accounts = isV1 ? getV1Wallets() : web3.eth.accounts;


### PR DESCRIPTION
In the case `web3` is not defined in the browser, the value of `window.web3` is `null` which causes an exception to be raised at a browser level. By moving it inside the try/catch scope we can swallow the exception and return the correct "your browser does not support web3" screen.