### PR TITLE
fix expected string for web3.networkId

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -22,7 +22,7 @@ const childContextTypes = {
     accounts: PropTypes.array,
     selectedAccount: PropTypes.string,
     network: PropTypes.string,
-    networkId: PropTypes.string
+    networkId: PropTypes.number
   })
 };
 


### PR DESCRIPTION
With Web3.js v1.0.0-beta.31 I get

`Warning: Failed child context type: Invalid child context web3.networkId of type number supplied to Web3Provider, expected string.`

Maybe a new change in Web3.js. This should fix it.
