### PR TITLE
Implement minimal EIP 1102 support

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -102,15 +102,12 @@ class Web3Provider extends React.Component {
     const ethAccounts = this.getAccounts();
 
     if (isEmpty(ethAccounts)) {
-      web3 && web3.eth && web3.eth.getAccounts((err, accounts) => {
-
-        if (err) {
-          this.setState({
-            accountsError: err
-          });
-        } else {
-          this.handleAccounts(accounts);
-        }
+      web3 && web3.currentProvider && web3.currentProvider.enable()
+      .then(accounts => this.handleAccounts(accounts))
+      .catch((err) => {
+        this.setState({
+          accountsError: err
+        });
       });
     } else {
       this.handleAccounts(ethAccounts);

--- a/test/Web3Provider.test.js
+++ b/test/Web3Provider.test.js
@@ -63,6 +63,7 @@ function runTests(version) {
           expect(spy.callCount).to.be.above(1);
           spy.restore();
         });
+
         it('should set context.accounts if available', () => {
           window.web3.setAccounts(['0x987']);
           const wrapper = getMount();

--- a/test/helpers/web3-v1.mock.js
+++ b/test/helpers/web3-v1.mock.js
@@ -15,6 +15,11 @@ const web3 = {
       getId: cb => cb(null, network)
     }
   },
+  currentProvider: {
+    enable: () => {
+      return Promise.resolve(accounts)
+    },
+  },
   setNetwork: v => network = v,
   setAccounts: v => {
     accounts = v;

--- a/test/helpers/web3.mock.js
+++ b/test/helpers/web3.mock.js
@@ -11,6 +11,11 @@ module.exports = {
   version: {
     getNetwork: () => network
   },
+  currentProvider: {
+    enable: () => {
+      return Promise.resolve(accounts)
+    },
+  },
   setNetwork: v => network = v,
   setAccounts: v => accounts = v,
   restore: () => {


### PR DESCRIPTION
For some reason some tests have broken, and I can't tell why. Opening a PR so someone else could take a look maybe. I'll try to chip away at this as time allows.

This minimal version of [EIP 1102 support](https://medium.com/metamask/eip-1102-preparing-your-dapp-5027b2c9ed76) simply requests user login when the component loads.

Another, more nuanced approach would be to show a login widget that allows users to deliberately login if they want, or to remain anonymous and continue using the page.

I have a basic implementation of that [on another branch](https://github.com/danfinlay/react-web3/tree/LoginPage).

Fixes #35