### PR TITLE
Do not render AccountUnavailableComponent until handleAccounts is done

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -38,6 +38,7 @@ class Web3Provider extends React.Component {
 
     this.state = {
       accounts,
+      fetchedAccounts: false,
       networkId: null,
       networkError: null
     };
@@ -112,6 +113,7 @@ class Web3Provider extends React.Component {
     } else {
       this.handleAccounts(ethAccounts);
     }
+
   }
 
   handleAccounts(accounts, isConstructor = false) {
@@ -164,6 +166,7 @@ class Web3Provider extends React.Component {
         })
       }
     }
+    this.setState({fetchedAccounts: true})
   }
 
   /**
@@ -218,6 +221,7 @@ class Web3Provider extends React.Component {
 
   render() {
     const { web3 } = window;
+    const { fetchedAccounts } = this.state;
     const {
       passive,
       web3UnavailableScreen: Web3UnavailableComponent,
@@ -232,7 +236,7 @@ class Web3Provider extends React.Component {
       return <Web3UnavailableComponent />;
     }
 
-    if (isEmpty(this.state.accounts)) {
+    if (isEmpty(this.state.accounts) && fetchedAccounts) {
       return <AccountUnavailableComponent />;
     }
 

--- a/test/provider-styles.test.js
+++ b/test/provider-styles.test.js
@@ -8,13 +8,16 @@ import Component from './helpers/Component';
 import { wait, getWrapper, getMount } from './helpers/utils';
 
 describe('Styles', function () {
-
-  it('should load default stylesheet', () => {
+  it('should load default stylesheet', async () => {
     const wrapper = mount(
       <Web3Provider>
         <div id="foo" />
       </Web3Provider>
     );
+
+    const instance = wrapper.instance();
+    await instance.fetchAccounts()
+
     const html = wrapper.html();
 
     expect(html).to.contain(`<style>`);


### PR DESCRIPTION
Web3Provider provider is rendering prior to handleAccounts() finishing causing the `AccountUnavailable` component to briefly render on page refresh/load even when Metamask is connected with accounts.

I added a flag to track whether `handleAccounts()` is done and only render `AccountUnavailable` once we attempted to check for accounts.

https://github.com/coopermaruyama/react-web3/issues/36