### PR TITLE
Use flag to check if we fetched accounts before displaying AccountsUnavailable

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -38,6 +38,7 @@ class Web3Provider extends React.Component {
 
     this.state = {
       accounts,
+      accountsLoaded: false,
       networkId: null,
       networkError: null
     };
@@ -103,12 +104,14 @@ class Web3Provider extends React.Component {
 
     if (isEmpty(ethAccounts)) {
       web3 && web3.currentProvider && web3.currentProvider.enable()
-      .then(accounts => this.handleAccounts(accounts))
-      .catch((err) => {
-        this.setState({
-          accountsError: err
+        .then((accounts) => {
+          this.setState({ accountsLoaded: true })
+          this.handleAccounts(accounts)
+        })
+        .catch((err) => {
+           this.setState({ accountsError: err});
         });
-      });
+
     } else {
       this.handleAccounts(ethAccounts);
     }
@@ -218,6 +221,7 @@ class Web3Provider extends React.Component {
 
   render() {
     const { web3 } = window;
+    const { accountsLoaded } = this.state;
     const {
       passive,
       web3UnavailableScreen: Web3UnavailableComponent,
@@ -232,7 +236,7 @@ class Web3Provider extends React.Component {
       return <Web3UnavailableComponent />;
     }
 
-    if (isEmpty(this.state.accounts)) {
+    if (isEmpty(this.state.accounts) && accountsLoaded) {
       return <AccountUnavailableComponent />;
     }
 

--- a/test/provider-styles.test.js
+++ b/test/provider-styles.test.js
@@ -8,13 +8,16 @@ import Component from './helpers/Component';
 import { wait, getWrapper, getMount } from './helpers/utils';
 
 describe('Styles', function () {
-
-  it('should load default stylesheet', () => {
+  it('should load default stylesheet', async () => {
     const wrapper = mount(
       <Web3Provider>
         <div id="foo" />
       </Web3Provider>
     );
+
+    const instance = wrapper.instance();
+    await instance.fetchAccounts()
+
     const html = wrapper.html();
 
     expect(html).to.contain(`<style>`);


### PR DESCRIPTION
This is a fix to https://github.com/coopermaruyama/react-web3/issues/36 where we see AccountUnavailable flickering briefly even when a user has Metamask connected with an account.

Added a flag to check whether we've attempted to fetch accounts before rendering AccountsUnavailable.

Tests are ✅ ✅ ✅ 