### PR TITLE
Feature/use window ethereum

### DIFF
--- a/src/Web3Provider.jsx
+++ b/src/Web3Provider.jsx
@@ -98,17 +98,17 @@ class Web3Provider extends React.Component {
    * @return {void}
    */
   fetchAccounts() {
-    const { web3 } = window;
+    const { ethereum } = window;
     const ethAccounts = this.getAccounts();
 
     if (isEmpty(ethAccounts)) {
-      web3 && web3.currentProvider && web3.currentProvider.enable()
-      .then(accounts => this.handleAccounts(accounts))
-      .catch((err) => {
-        this.setState({
-          accountsError: err
+      ethereum && ethereum.enable()
+        .then(accounts => this.handleAccounts(accounts))
+        .catch((err) => {
+          this.setState({
+            accountsError: err
+          });
         });
-      });
     } else {
       this.handleAccounts(ethAccounts);
     }

--- a/test/.setup.js
+++ b/test/.setup.js
@@ -1,6 +1,7 @@
 require('babel-polyfill');
 const { JSDOM } = require('jsdom');
 const web3 = require('./helpers/web3.mock.js');
+const ethereum = require('./helpers/ethereum.mock.js')
 const web3_v1 = require('./helpers/web3-v1.mock.js');
 
 const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
@@ -13,6 +14,8 @@ function copyProps(src, target) {
   Object.defineProperties(target, props);
 }
 
+window.ethereum = ethereum;
+global.ethereum = ethereum;
 window.web3 = web3;
 global.web3 = web3;
 window.web3_v1 = web3_v1;

--- a/test/Web3Provider.test.js
+++ b/test/Web3Provider.test.js
@@ -24,6 +24,7 @@ function runTests(version) {
         if (version === 'v1') {
           window.web3 = window.web3_v1;
         } else {
+          console.log("yo", window.ethereum)
           window.web3 = web3_v0;
         }
 
@@ -65,7 +66,7 @@ function runTests(version) {
         });
 
         it('should set context.accounts if available', async () => {
-          window.web3.setAccounts(['0x987']);
+          window.ethereum.setAccounts(['0x987']);
           const wrapper = getMount();
           const instance = wrapper.instance();
           await instance.fetchAccounts()
@@ -94,7 +95,7 @@ function runTests(version) {
       describe('Redux Integration', function () {
         describe('When accounts becomes available', () => {
           it('dispatches an action', async () => {
-            window.web3.setAccounts(['0x111']);
+            window.ethereum.setAccounts(['0x111']);
             const spy = sinon.spy();
             const wrapper = mount(
               <Web3Provider>
@@ -119,7 +120,7 @@ function runTests(version) {
         });
         describe('When switching between accounts', () => {
           it('dispatches an action', async () => {
-            window.web3.setAccounts(['0x111']);
+            window.ethereum.setAccounts(['0x111']);
             const spy = sinon.spy();
             const wrapper = mount(
               <Web3Provider>
@@ -135,7 +136,8 @@ function runTests(version) {
             );
 
             // simulate changing account
-            window.web3.setAccounts(['0x222']);
+            window.ethereum.setAccounts(['0x222']);
+
             await wrapper.instance().fetchAccounts()
             clock.tick(1500);
 
@@ -148,7 +150,8 @@ function runTests(version) {
 
         describe('When logging out', () => {
           it('dispatches an action', async () => {
-            window.web3.setAccounts(['0x111']);
+            window.ethereum.setAccounts(['0x111']);
+
             const spy = sinon.spy();
             const wrapper = mount(
               <Web3Provider>
@@ -164,7 +167,7 @@ function runTests(version) {
             );
 
             // simulate logging out
-            window.web3.setAccounts([]);
+            window.ethereum.setAccounts([]);
             await wrapper.instance().fetchAccounts()
             clock.tick(1500);
 

--- a/test/Web3Provider.test.js
+++ b/test/Web3Provider.test.js
@@ -10,8 +10,6 @@ import { wait, getWrapper, getMount } from './helpers/utils';
 let clock;
 const { window } = global;
 
-const web3_v0 = window.web3;
-
 /**
  * We wrap all the tests in a function so we can run with web3 < 1.0 and again
  * with web3 >= 1.0
@@ -24,8 +22,7 @@ function runTests(version) {
         if (version === 'v1') {
           window.web3 = window.web3_v1;
         } else {
-          console.log("yo", window.ethereum)
-          window.web3 = web3_v0;
+          window.web3 = window.web3;
         }
 
         clock = sinon.useFakeTimers();

--- a/test/Web3Provider.test.js
+++ b/test/Web3Provider.test.js
@@ -21,8 +21,6 @@ function runTests(version) {
 
         if (version === 'v1') {
           window.web3 = window.web3_v1;
-        } else {
-          window.web3 = window.web3;
         }
 
         clock = sinon.useFakeTimers();

--- a/test/helpers/ethereum.mock.js
+++ b/test/helpers/ethereum.mock.js
@@ -1,0 +1,9 @@
+let defaultAccounts = [];
+let accounts = defaultAccounts.slice();
+
+module.exports = {
+  setAccounts: v => accounts = v,
+  enable: () => {
+    return Promise.resolve(accounts)
+  },
+};

--- a/test/helpers/web3.mock.js
+++ b/test/helpers/web3.mock.js
@@ -17,7 +17,6 @@ module.exports = {
     },
   },
   setNetwork: v => network = v,
-  setAccounts: v => accounts = v,
   restore: () => {
     accounts = defaultAccounts.slice();
     network = defaultNetwork;


### PR DESCRIPTION
The new, standard way to access the Ethereum provider in a Web browser is to use `window.ethereum`

https://medium.com/metamask/eip-1102-preparing-your-dapp-5027b2c9ed76